### PR TITLE
Add unique history for controller

### DIFF
--- a/lib/components/persistent_tab_view.dart
+++ b/lib/components/persistent_tab_view.dart
@@ -430,7 +430,8 @@ class _PersistentTabViewState extends State<PersistentTabView> {
       widget.handleAndroidBackButtonPress &&
       widget.onWillPop == null &&
       _controller.historyIsEmpty() &&
-      _navigatorKeys[_controller.index].currentState != null && // Required if historyLength == 0 because historyIsEmpty() is already true when switching to uninitialized tabs instead of only when going back.
+      _navigatorKeys[_controller.index].currentState !=
+          null && // Required if historyLength == 0 because historyIsEmpty() is already true when switching to uninitialized tabs instead of only when going back.
       (subtreeCantHandlePop ??
           !_navigatorKeys[_controller.index].currentState!.canPop());
 }

--- a/lib/models/persistent_tab_controller.dart
+++ b/lib/models/persistent_tab_controller.dart
@@ -22,7 +22,8 @@ class PersistentTabController extends ChangeNotifier {
         _clearHistoryOnInitialIndex = clearHistoryOnInitialIndex,
         _index = initialIndex,
         assert(initialIndex >= 0, "Nav Bar item index cannot be less than 0"),
-        assert(historyLength >= 0, "Nav Bar history length cannot be less than 0");
+        assert(
+            historyLength >= 0, "Nav Bar history length cannot be less than 0");
 
   final int _initialIndex;
   final int _historyLength;
@@ -42,7 +43,9 @@ class PersistentTabController extends ChangeNotifier {
       if (_clearHistoryOnInitialIndex && value == _initialIndex) {
         _tabHistory.clear();
       } else {
-        if (_historyLength == 1 && _tabHistory.length == 1 && _tabHistory[0] == value) {
+        if (_historyLength == 1 &&
+            _tabHistory.length == 1 &&
+            _tabHistory[0] == value) {
           // Clear history when switching to initial tab and it is the only entry in history.
           _tabHistory.clear();
         } else if (_historyLength > 0) {

--- a/test/persistent_tab_view_test.dart
+++ b/test/persistent_tab_view_test.dart
@@ -41,7 +41,8 @@ void expectScreen(int? id, {int screenCount = 3}) {
   }
 
   for (int i = 1; i <= screenCount; i++) {
-    expect(find.text("Screen$i").hitTestable(), id == i ? findsOneWidget : findsNothing);
+    expect(find.text("Screen$i").hitTestable(),
+        id == i ? findsOneWidget : findsNothing);
   }
 }
 
@@ -371,9 +372,9 @@ void main() {
       testWidgets("pops main screen when historyLength is 1", (tester) async {
         await tester.pumpWidget(
           wrapTabViewWithMainScreen(
-                (context) => PersistentTabView(
+            (context) => PersistentTabView(
               controller:
-              PersistentTabController(initialIndex: 1, historyLength: 1),
+                  PersistentTabController(initialIndex: 1, historyLength: 1),
               tabs: [1, 2, 3]
                   .map((id) => tabConfig(id, defaultScreen(id)))
                   .toList(),
@@ -398,12 +399,14 @@ void main() {
         expectScreen(null);
       });
 
-      testWidgets("pops main screen when historyLength is 1 and switched to initial tab", (tester) async {
+      testWidgets(
+          "pops main screen when historyLength is 1 and switched to initial tab",
+          (tester) async {
         await tester.pumpWidget(
           wrapTabViewWithMainScreen(
-                (context) => PersistentTabView(
+            (context) => PersistentTabView(
               controller:
-              PersistentTabController(initialIndex: 1, historyLength: 1),
+                  PersistentTabController(initialIndex: 1, historyLength: 1),
               tabs: [1, 2, 3]
                   .map((id) => tabConfig(id, defaultScreen(id)))
                   .toList(),
@@ -429,14 +432,17 @@ void main() {
         expectScreen(null);
       });
 
-      testWidgets("pops main screen when historyLength is 1 and initial tab has subpage", (tester) async {
+      testWidgets(
+          "pops main screen when historyLength is 1 and initial tab has subpage",
+          (tester) async {
         await tester.pumpWidget(
           wrapTabViewWithMainScreen(
-                (context) => PersistentTabView(
+            (context) => PersistentTabView(
               controller:
-              PersistentTabController(initialIndex: 1, historyLength: 1),
+                  PersistentTabController(initialIndex: 1, historyLength: 1),
               tabs: [1, 2, 3]
-                  .map((id) => tabConfig(id, id == 2 ? screenWithSubPages(id) : defaultScreen(id)))
+                  .map((id) => tabConfig(
+                      id, id == 2 ? screenWithSubPages(id) : defaultScreen(id)))
                   .toList(),
               navBarBuilder: (config) =>
                   Style1BottomNavBar(navBarConfig: config),
@@ -469,9 +475,9 @@ void main() {
       testWidgets("pops main screen when historyLength is 2", (tester) async {
         await tester.pumpWidget(
           wrapTabViewWithMainScreen(
-                (context) => PersistentTabView(
+            (context) => PersistentTabView(
               controller:
-              PersistentTabController(initialIndex: 1, historyLength: 2),
+                  PersistentTabController(initialIndex: 1, historyLength: 2),
               tabs: [1, 2, 3]
                   .map((id) => tabConfig(id, defaultScreen(id)))
                   .toList(),
@@ -503,12 +509,16 @@ void main() {
         expectScreen(null);
       });
 
-      testWidgets("pops main screen when historyLength is 2 and clearing history", (tester) async {
+      testWidgets(
+          "pops main screen when historyLength is 2 and clearing history",
+          (tester) async {
         await tester.pumpWidget(
           wrapTabViewWithMainScreen(
-                (context) => PersistentTabView(
-              controller:
-              PersistentTabController(initialIndex: 1, historyLength: 2, clearHistoryOnInitialIndex: true),
+            (context) => PersistentTabView(
+              controller: PersistentTabController(
+                  initialIndex: 1,
+                  historyLength: 2,
+                  clearHistoryOnInitialIndex: true),
               tabs: [1, 2, 3]
                   .map((id) => tabConfig(id, defaultScreen(id)))
                   .toList(),


### PR DESCRIPTION
Allows the `PersistentTabController` history to be unique, meaning that each tab will have only one entry in the history. Initial tab will always keep the first index.

When 3 tabs are shown (0, 1, 2) switch tabs in the following order (1, 2, 1, 0, 2).
Going back from tab 2 will go to 1 then 0 and exit.
