### PR TITLE
Update go_router to version 14

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  go_router: ^13.2.0
+  go_router: ^14.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The version 14 of `go_router` introduces a breaking change on the `onExit` method wich takes 2 parameters in input. These changes do not impact `PersistentBottomNavBarV2` as the `onExit` method are not in use.

This is to avoid version conflicts for projects that use both `go_router` and `PersistentBottomNavBarV2` and need to update to the latest versions of both