### PR TITLE
Fix exception if number of tabs changes

### DIFF
--- a/lib/components/persistent_tab_view_scaffold.dart
+++ b/lib/components/persistent_tab_view_scaffold.dart
@@ -378,8 +378,9 @@ class _TabSwitchingView extends StatefulWidget {
 
 class _TabSwitchingViewState extends State<_TabSwitchingView>
     with TickerProviderStateMixin {
-  late final List<bool> shouldBuildTab =
-      List<bool>.filled(widget.tabCount, false);
+  late final List<bool> shouldBuildTab = [
+    ...List<bool>.filled(widget.tabCount, false),
+  ];
   final List<FocusScopeNode> tabFocusNodes = <FocusScopeNode>[];
   final List<FocusScopeNode> discardedNodes = <FocusScopeNode>[];
   late AnimationController _animationController;


### PR DESCRIPTION
Fixes this exception:

```
════════ Exception caught by widgets library ═══════════════════════════════════
The following UnsupportedError was thrown building MediaQuery(MediaQueryData(size: Size(448.0, 949.3), devicePixelRatio: 3.0, textScaler: no scaling, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, systemGestureInsets: EdgeInsets(0.0, 24.0, 0.0, 0.0), alwaysUse24HourFormat: false, accessibleNavigation: false, highContrast: false, onOffSwitchLabels: false, disableAnimations: false, invertColors: false, boldText: false, navigationMode: traditional, gestureSettings: DeviceGestureSettings(touchSlop: 8.0), displayFeatures: [])):
Unsupported operation: Cannot remove from a fixed-length list

The relevant error-causing widget was:
    PersistentTabView PersistentTabView:file:///home/luke/Work/click/click_flutter/lib/pages/screens/widgets/navigation_tabs.dart:191:14

When the exception was thrown, this was the stack:
#0      FixedLengthListMixin.removeRange (dart:_internal/list.dart:71:5)
#1      _TabSwitchingViewState.didUpdateWidget (package:persistent_bottom_nav_bar_v2/components/persistent_tab_view_scaffold.dart:546:22)
persistent_tab_view_scaffold.dart:546
#2      StatefulElement.update (package:flutter/src/widgets/framework.dart:5653:55)
framework.dart:5653
```