### PR TITLE
Only dispose controller if it is not owned by parent

### DIFF
--- a/lib/components/persistent_tab_view.dart
+++ b/lib/components/persistent_tab_view.dart
@@ -269,7 +269,9 @@ class _PersistentTabViewState extends State<PersistentTabView> {
 
   @override
   void dispose() {
-    _controller.dispose();
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
Only dispose controller if it is not owned by parent. Fixes #153.