### PR TITLE
Fix 'Null check operator used on a null value'

### DIFF
--- a/lib/components/persistent_tab_view.dart
+++ b/lib/components/persistent_tab_view.dart
@@ -402,15 +402,17 @@ class _PersistentTabViewState extends State<PersistentTabView> {
   void popAllScreens() {
     if (widget.popAllScreensOnTapOfSelectedTab ||
         widget.popAllScreensOnTapAnyTabs) {
-      final navigator = _navigatorKeys[_controller.index].currentState!;
-      if (!navigator.canPop()) {
-        widget.tabs[_controller.index].onSelectedTabPressWhenNoScreensPushed
-            ?.call();
-      } else {
-        if (widget.popActionScreens == PopActionScreensType.once) {
-          navigator.maybePop(context);
+      final navigator = _navigatorKeys[_controller.index].currentState;
+      if (navigator != null) {
+        if (!navigator.canPop()) {
+          widget.tabs[_controller.index].onSelectedTabPressWhenNoScreensPushed
+              ?.call();
         } else {
-          navigator.popUntil((route) => route.isFirst);
+          if (widget.popActionScreens == PopActionScreensType.once) {
+            navigator.maybePop(context);
+          } else {
+            navigator.popUntil((route) => route.isFirst);
+          }
         }
       }
     }
@@ -423,5 +425,5 @@ class _PersistentTabViewState extends State<PersistentTabView> {
       _navigatorKeys[_controller.index].currentState !=
           null && // Required if historyLength == 0 because historyIsEmpty() is already true when switching to uninitialized tabs instead of only when going back.
       (subtreeCantHandlePop ??
-          !_navigatorKeys[_controller.index].currentState!.canPop());
+          !(_navigatorKeys[_controller.index].currentState?.canPop() ?? false));
 }


### PR DESCRIPTION
Gets rid of unchecked use of `!`...

The exception can be triggered on a hot reload, or probably in other situations too.