### PR TITLE
Update CustomNavBar example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,43 +149,45 @@ class CustomNavBar extends StatelessWidget {
   final NavBarConfig navBarConfig;
   final NavBarDecoration navBarDecoration;
 
-  CustomNavBar({
-    Key key,
-    @required this.navBarConfig,
+  const CustomNavBar({
+    super.key,
+    required this.navBarConfig,
     this.navBarDecoration = const NavBarDecoration(),
-  }) : super(key: key);
+  });
 
   Widget _buildItem(ItemConfig item, bool isSelected) {
+    final title = item.title;
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: <Widget>[
+      children: [
         Expanded(
           child: IconTheme(
             data: IconThemeData(
-                size: item.iconSize,
-                color: isSelected
-                    ? item.activeColorPrimary
-                    : item.inactiveColorPrimary),
+              size: item.iconSize,
+              color: isSelected
+                      ? item.activeForegroundColor
+                      : item.inactiveForegroundColor,
+            ),
             child: isSelected ? item.icon : item.inactiveIcon,
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.only(top: 15.0),
-          child: Material(
-            type: MaterialType.transparency,
-            child: FittedBox(
-              child: Text(
-                item.title,
-                style: item.textStyle.apply(
-                  color: isSelected
-                      ? item.activeColorPrimary
-                      : item.inactiveColorPrimary,
+        if (title != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 15.0),
+            child: Material(
+              type: MaterialType.transparency,
+              child: FittedBox(
+                child: Text(
+                  title,
+                  style: item.textStyle.apply(
+                    color: isSelected
+                            ? item.activeForegroundColor
+                            : item.inactiveForegroundColor,
+                  ),
                 ),
               ),
             ),
           ),
-        ),
       ],
     );
   }
@@ -193,27 +195,21 @@ class CustomNavBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DecoratedNavBar(
-      decoration: this.navBarDecoration,
-      filter: this.navBarConfig.selectedItem.filter,
-      opacity: this.navBarConfig.selectedItem.opacity,
-      height: this.navBarConfig.navBarHeight,
+      decoration: navBarDecoration,
+      height: navBarConfig.navBarHeight,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         crossAxisAlignment: CrossAxisAlignment.center,
-        children: this.navBarConfig.items.map((item) {
-          int index = this.navBarConfig.items.indexOf(item);
-          return Expanded(
-            child: InkWell(
-              onTap: () {
-                this.navBarConfig.onItemSelected(index); // This is the most important part. Without this, nothing would happen if you tap on an item.
-              },
-              child: _buildItem(
-                item,
-                this.navBarConfig.selectedIndex == index,
+        children: [
+          for (final (index, item) in navBarConfig.items.indexed)
+            Expanded(
+              child: InkWell(
+                // This is the most important part. Without this, nothing would happen if you tap on an item.
+                onTap: () => navBarConfig.onItemSelected(index),
+                child: _buildItem(item, navBarConfig.selectedIndex == index),
               ),
             ),
-          );
-        }).toList(),
+        ],
       ),
     );
   }


### PR DESCRIPTION
I have noticed the `CustomNavBar` example in the readme has not been updated for v5 yet.

I have updated it to work with the current version, but am not entirely sure if I have managed to faithfully adapt properties to the new schema, especially `DecoratedNavBar.opacity = navBarConfig.selectedItem.opacity` which I have simply left out.