### PR TITLE
Fix duplicates tabs in history

### DIFF
--- a/lib/models/persistent_tab_controller.dart
+++ b/lib/models/persistent_tab_controller.dart
@@ -49,7 +49,10 @@ class PersistentTabController extends ChangeNotifier {
           // Clear history when switching to initial tab and it is the only entry in history.
           _tabHistory.clear();
         } else if (_historyLength > 0) {
-          _tabHistory.add(_index);
+          // Removes duplicates tab from history
+          _tabHistory
+            ..remove(_index)
+            ..add(_index);
         }
 
         if (_tabHistory.length > _historyLength) {

--- a/lib/models/persistent_tab_controller.dart
+++ b/lib/models/persistent_tab_controller.dart
@@ -51,7 +51,7 @@ class PersistentTabController extends ChangeNotifier {
         } else if (_historyLength > 0) {
           // Removes duplicates tab from history
           _tabHistory
-            ..remove(_index)
+            ..remove(value)
             ..add(_index);
         }
 


### PR DESCRIPTION
When jumping to tab removes it if already in tabHistory 